### PR TITLE
feat: Makefile file path convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-MAPSHAPER = ./node_modules/.bin/mapshaper
+MAPSHAPER = npx mapshaper
 
 RAW_DIR = raw
 CSV_DIR = csv
 SPLIT_DIR = split
 TOPOJSON_DIR = topojson
 
-COUNTIES_SHP = $(RAW_DIR)/COUNTY_MOI_1060525.shp
-TOWNS_SHP = $(RAW_DIR)/TOWN_MOI_1061130.shp
-VILLAGES_SHP = $(RAW_DIR)/VILLAGE_MOI_1061130.shp
+COUNTIES_SHP = $(RAW_DIR)/counties.shp
+TOWNS_SHP = $(RAW_DIR)/towns.shp
+VILLAGES_SHP = $(RAW_DIR)/villages.shp
 
 COUNTIES_CSV = $(CSV_DIR)/counties.csv
 TOWNS_CSV = $(CSV_DIR)/towns.csv

--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@
 
 要重新生成 TopoJSON 檔，請先從下節「資料來源」下載所需的原始檔案，並解壓縮到 `raw/` 目錄中。
 
-接著，安裝 [mapshaper](https://github.com/mbloch/mapshaper)，並執行以下命令：
+**重要：** 為了讓建置流程順利運作，請將解壓縮後的 `Shapefile`（包含 `.shp`, `.shx`, `.dbf` 等副檔名）依照以下規則重新命名：
+*   直轄市、縣市界線圖資 -> `counties` (例如 `COUNTY_MOI_1060525.shp` -> `counties.shp`)
+*   鄉鎮市區界線圖資 -> `towns` (例如 `TOWN_MOI_1061130.shp` -> `towns.shp`)
+*   村里界圖圖資 -> `villages` (例如 `VILLAGE_NLSC_1140620.shp` -> `villages.shp`)
+
+接著，安裝 [mapshaper](https://github.com/mbloch/mapshaper)（若尚未安裝），並執行以下命令：
 
 ```
 $ make split-all topojson-all
@@ -39,6 +44,12 @@ $ make split-towns topojson-towns
 $ make villages/villages-6300500.json
 ```
 
+## 踩坑紀錄
+1. 如果遇到`make: Nothing to be done for ...`:
+
+  執行 `make clean-..`. 命令，例如`clean-topojson-villages`
+
+ `make`透過判斷「目標檔案」是否已經存在，以及它的「依賴檔案」是否比它更新，來決定是否需要執行某個命令。
 
 ## 資料來源
 


### PR DESCRIPTION
## Problem
1. `Makefile` 中的原始檔名被hardcoded：Makefile
      直接依賴從政府開放平台下載的特定檔名（如COUNTY_MOI_1060525.shp）。然而，這些檔名會隨著政府更新資料而改變，導致Makefile 隨時可能失效。
2. `mapshaper` 路徑不穩健：Makefile 中使用相對路徑(`./node_modules/.bin/mapshaper`) 來呼叫 `mapshaper`，這在某些環境下可能會因為PATH 變數的設定而出錯。

## Update
1. 採用「convention over configuration」的原則：
       * 修改 Makefile，將寫死的檔名改為固定的、簡單的約定名稱（`counties.shp,
         towns.shp, villages.shp`）。
       * 同步更新 `README.md`